### PR TITLE
Modify the Server::getMessages() API

### DIFF
--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -336,6 +336,9 @@ class Server
                 if(isset($limit) && is_numeric($limit) && $limit < $numMessages)
                         $numMessages = $limit;
 
+                if ($numMessages < 1)
+                        return array();
+
                 $stream = $this->getImapStream();
                 $messages = array();
                 for($i = 1; $i <= $numMessages; $i++)


### PR DESCRIPTION
Modified the Server::getMessages() API to make it always return an array, instead of returning false when there are no messages.
