### PR TITLE
Fix imap_reopen 'mailbox not found' error

### DIFF
--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -260,7 +260,7 @@ class Server
         {
                 if(isset($this->imapStream))
                 {
-                        if(!imap_reopen($this->imapStream, $this->mailbox, $this->options, 1))
+                        if(!imap_reopen($this->imapStream, $this->getServerString(), $this->options, 1))
                                 throw new \RuntimeException(imap_last_error());
                 }else{
                         $imapStream = imap_open($this->getServerString(), $this->username, $this->password, $this->options, 1);


### PR DESCRIPTION
When this method was called and tried to reopen the imap connection, an error was thrown because the second argument must be the complete mailbox path and not only mailbox name (http://lu.php.net/manual/en/function.imap-reopen.php). 
