### PR TITLE
Fix notice undefined index charset

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -414,7 +414,7 @@ class Message
 
             $messageBody = self::decode($messageBody, $structure->encoding);
 
-            if ($parameters['charset'] !== self::$charset)
+            if (!empty($parameters['charset']) && $parameters['charset'] !== self::$charset)
                 $messageBody = iconv($parameters['charset'], self::$charset, $messageBody);
 
             if (strtolower($structure->subtype) == 'plain' || $structure->type == 1) {


### PR DESCRIPTION
There is a notice undefined index 'charset' when fetching a multipart email.
