### PR TITLE
Move message fix

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -651,8 +651,8 @@ class Message
     public function moveToMailBox($mailbox)
     {
         $returnValue = imap_mail_copy($this->imapStream, $this->uid, $mailbox, CP_UID | CP_MOVE);
-		imap_expunge($this->imapStream);
+        imap_expunge($this->imapStream);
 
-		return $returnValue;
+        return $returnValue;
     }
 }


### PR DESCRIPTION
Move message leaves back a copy of the original file makred for deletion.
Calling imap_expunge remove the file.
http://www.php.net/manual/en/function.imap-expunge.php
