### PR TITLE
Added getStructure() function to the Attachment class.

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -159,6 +159,16 @@ class Attachment
     }
 
     /**
+     * This function returns the object that contains the structure of this attachment.
+     * 
+     * @return \stdClass
+     */
+    public function getStructure()
+    {
+        return $this->structure;
+    }
+
+    /**
      * This function saves the attachment to the passed directory, keeping the original name of the file.
      *
      * @param  string $path


### PR DESCRIPTION
I think this function would be very useful for places where the existing functions can't provide all of the information. For example, I need to get the content ID of all images from an email, at the moment I'm having to grab the message structure and parse through it while taking educated guesses as to which Attachment ties to which part. 

Getting the Attachment's structure directly would allow for this without any guesswork.
