### PR TITLE
fixed bug in getting reply_to addresses

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -311,7 +311,8 @@ class Message
             }
         } else {
             if (!isset($this->plaintextMessage) && isset($this->htmlMessage)) {
-                $output = strip_tags($this->htmlMessage);
+                $output = preg_replace('/\<br(\s*)?\/?\>/i', PHP_EOL, trim($this->htmlMessage) );
+                $output = strip_tags($output);
 
                 return $output;
             } elseif (isset($this->plaintextMessage)) {


### PR DESCRIPTION
there was a problem in getting the reply_to address because the the variable name `Message->replyTo` that holds the reply_to address was different then the one used in `Message->getAddresses()`
