### PR TITLE
[WIP] Issue with emails attached to an email

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -109,11 +109,11 @@ class Attachment
     }
 
     /**
-     * This function returns the data of the attachment. Combined with 
+     * This function returns the data of the attachment. Combined with
      * getMimeType() it can be used to directly output data to a browser.
-     * 
-     * If the attachment file is message/rfc822, skip processing/decoding the 
-     * contents in order to avoid mangling the file. Otherwise, decode as 
+     *
+     * If the attachment file is message/rfc822, skip processing/decoding the
+     * contents in order to avoid mangling the file. Otherwise, decode as
      * normal to ensure other files are handled correctly.
      *
      * @return string

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -445,16 +445,16 @@ class Message
 
     /**
      * Adds an attachment
-     * 
-     * If a filename is not provided and the attachment is a message/rfc822 
-     * email, parse the Subject line and use it as the filename. If the Subject 
-     * line is blank or illegible, use a default filename (like Gmail and some 
+     *
+     * If a filename is not provided and the attachment is a message/rfc822
+     * email, parse the Subject line and use it as the filename. If the Subject
+     * line is blank or illegible, use a default filename (like Gmail and some
      * desktop clients do)
      *
-     * @param array     $parameters
-     * @param \stdClass $structure
-     * @param string    $partIdentifier
-     * @return boolean Successful attachment of file
+     * @param  array     $parameters
+     * @param  \stdClass $structure
+     * @param  string    $partIdentifier
+     * @return boolean   Successful attachment of file
      */
     protected function addAttachment($parameters, $structure, $partIdentifier)
     {
@@ -462,10 +462,10 @@ class Message
             $body = isset($partIdentifier) ?
                 imap_fetchbody($this->imapStream, $this->uid, $partIdentifier, FT_UID)
                 : imap_body($this->imapStream, $this->uid, FT_UID);
-            
+
             $headers = iconv_mime_decode_headers($body, 0, self::$charset);
             $filename = !empty($headers["Subject"]) ? $this->makeFilenameSafe($headers["Subject"]) : "email";
-            
+
             $dpar = new \stdClass();
             $dpar->attribute = "filename";
             $dpar->value = str_replace(array("\r", "\n"), '', $filename) . ".eml";
@@ -483,14 +483,14 @@ class Message
     }
 
     /**
-     * This function extracts the body of an email part, strips harmful 
-     * Outlook-specific strings from it, processes any encoded one-liners, 
-     * decodes it, converts it to the charset of the parent message, and 
+     * This function extracts the body of an email part, strips harmful
+     * Outlook-specific strings from it, processes any encoded one-liners,
+     * decodes it, converts it to the charset of the parent message, and
      * returns the result.
      *
-     * @param array     $parameters
-     * @param \stdClass $structure
-     * @param string    $partIdentifier
+     * @param  array     $parameters
+     * @param  \stdClass $structure
+     * @param  string    $partIdentifier
      * @return string
      */
     protected function processBody($structure, $partIdentifier)
@@ -498,11 +498,11 @@ class Message
         $rawBody = isset($partIdentifier) ?
                 imap_fetchbody($this->imapStream, $this->uid, $partIdentifier, FT_UID)
                 : imap_body($this->imapStream, $this->uid, FT_UID);
-        
+
         $bodyNoOutlook = $this->stripOutlookSpecificStrings($rawBody);
-        
+
         $decodedBody = self::decode($bodyNoOutlook, $structure->encoding);
-        
+
         $inCharset = $inCharset = mb_detect_encoding($decodedBody, array(
             "US-ASCII",
             "ISO-8859-1",
@@ -520,41 +520,41 @@ class Message
             "UCS2",
             "UCS4")
         );
-        
+
         if ($inCharset && $inCharset !== self::$charset) {
             $decodedBody = iconv($inCharset, self::$charset, $decodedBody);
         }
 
         return $decodedBody;
     }
-    
+
     /**
-     * Removes "Thread-Index:" line from the message body which is placed there 
+     * Removes "Thread-Index:" line from the message body which is placed there
      * by Outlook and messes up the other processing steps.
-     * 
-     * @param string $messageBody
+     *
+     * @param  string $messageBody
      * @return string
      */
     protected function stripOutlookSpecificStrings($bodyBefore)
     {
         $bodyAfter = preg_replace('/Thread-Index:.*$/m', "", $bodyBefore);
-        
+
         return $bodyAfter;
     }
-    
+
     /**
-     * This function takes in a string to be used as a filename and replaces 
-     * any dangerous characters with underscores to ensure compatibility with 
+     * This function takes in a string to be used as a filename and replaces
+     * any dangerous characters with underscores to ensure compatibility with
      * various file systems
-     * 
-     * @param string $oldName
+     *
+     * @param  string $oldName
      * @return string
      */
     protected function makeFilenameSafe($oldName)
     {
         return preg_replace('/[<>"{}|\\\^\[\]`;\/\?:@&=$,]/',"_", $oldName);
     }
-    
+
     /**
      * This function takes in a structure and identifier and processes that part of the message. If that portion of the
      * message has its own subparts, those are recursively processed using this function.
@@ -565,7 +565,7 @@ class Message
     protected function processStructure($structure, $partIdentifier = null)
     {
         $attached = false;
-        
+
         // TODO: Get HTML attachments working, too!
         if (isset($structure->disposition) && $structure->disposition == "attachment") {
             $parameters = self::getParametersFromStructure($structure);
@@ -632,7 +632,7 @@ class Message
                 return $data;
         }
     }
-    
+
     /**
      * This function returns the body type that an imap integer maps to.
      *

--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -155,8 +155,7 @@ class Server
      */
     public function setMailBox($mailbox = '')
     {
-        if(!$this->hasMailBox($mailbox)) {
-
+        if (!$this->hasMailBox($mailbox)) {
             return false;
         }
 


### PR DESCRIPTION
We're using Fetch to grab emails and process attachments. I sent an email from Outlook for Mac with two other emails (.eml files) attached to it, one of which had a .xlsx file attached to it. Fetch only returns the .xlsx file as an attachment of the main email, completely ignoring (or parsing through) the attached .eml files. Is this intentional behaviour?

Structure of the email I sent:

```
main email
    .eml file
    .eml file
        .xlsx file
```

Structure of the data returned by ::getAttachments():

```
Array
(
    [0] => Fetch\Attachment Object
        (
            [structure:protected] => stdClass Object
                (
                    [type] => 3
                    [encoding] => 3
                    [ifsubtype] => 1
                    [subtype] => VND.OPENXMLFORMATS-OFFICEDOCUMENT.SPREADSHEETML.SHEET
                    [ifdescription] => 0
                    [ifid] => 0
                    [bytes] => 24576
                    [ifdisposition] => 1
                    [disposition] => attachment
                    [ifdparameters] => 1
                    [dparameters] => Array
                        (
                            [0] => stdClass Object
                                (
                                    [attribute] => filename
                                    [value] => document.xlsx
                                )

                        )

                    [ifparameters] => 1
                    [parameters] => Array
                        (
                            [0] => stdClass Object
                                (
                                    [attribute] => name
                                    [value] => document.xlsx
                                )

                        )

                )

            [messageId:protected] => 830
            [imapStream:protected] => Resource id #43
            [partId:protected] => 3.1.2
            [filename:protected] => document.xlsx
            [size:protected] => 24576
            [data:protected] => 
            [mimeType] => application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
            [encoding] => 3
        )

)
```

Am I just missing some configuration option or flag or something which will prevent this behaviour? I'm not able to ascertain just where in the code this manipulation/discarding of the attachments is occurring. Our intended use requires receiving unmodified attachments for processing and storage -- even .eml files (the contents of these .eml files, not their attachments, are what we're after, in most cases).
