### PR TITLE
Allow the passing of connection parameters to imap_open()

### DIFF
--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -94,6 +94,13 @@ class Server
     protected $options = 0;
 
     /**
+     * This is the set of connection parameters
+     *
+     * @var array
+     */
+    protected $params = array();
+
+    /**
      * This is the resource connection to the server. It is required by a number of imap based functions to specify how
      * to connect.
      *
@@ -225,6 +232,16 @@ class Server
     }
 
     /**
+     * This function is used to set connection parameters
+     *
+     * @param string $key
+     * @param string $value
+     */
+    public function setParam($key, $value) {
+        $this->params[$key] = $value;
+    }
+
+    /**
      * This function gets the current saved imap resource and returns it.
      *
      * @return resource
@@ -287,7 +304,7 @@ class Server
             if (!imap_reopen($this->imapStream, $this->getServerString(), $this->options, 1))
                 throw new \RuntimeException(imap_last_error());
         } else {
-            $imapStream = imap_open($this->getServerString(), $this->username, $this->password, $this->options, 1);
+            $imapStream = imap_open($this->getServerString(), $this->username, $this->password, $this->options, 1, $this->params);
 
             if ($imapStream === false)
                 throw new \RuntimeException(imap_last_error());


### PR DESCRIPTION
Since version 5.3.2 of PHP, imap_open() has an optional 6th
parameter which allows you to set certain connection parameters.

Currently the only key is:

- DISABLE_AUTHENTICATOR - Disable authentication properties

see https://bugs.php.net/bug.php?id=33500

Example of use:

  $server = new Server('imap.example.com', 993);
  $server->setParam('DISABLE_AUTHENTICATOR', 'GSSAPI');

This gets rid of the following errors:
<br />
<b>Notice</b>:  Unknown: Unknown GSSAPI failure: An invalid name was
supplied (errflg=1) in <b>Unknown</b> on line <b>0</b><br />
<br />
<b>Notice</b>:  Unknown: GSSAPI mechanism status: Hostname cannot be
canonicalized (errflg=1) in <b>Unknown</b> on line <b>0</b><br />