### PR TITLE
Add utf8_encode to messageBody for utf8 conversion.

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -437,8 +437,9 @@ class Message
 
             $messageBody = self::decode($messageBody, $structure->encoding);
 
-            if (!empty($parameters['charset']) && $parameters['charset'] !== self::$charset)
-                $messageBody = iconv($parameters['charset'], self::$charset, $messageBody);
+            if (!empty($parameters['charset']) && $parameters['charset'] !== self::$charset) {
+                $messageBody = iconv($parameters['charset'], self::$charset, utf8_encode($messageBody));
+            }
 
             if (strtolower($structure->subtype) === 'plain' || ($structure->type == 1 && strtolower($structure->subtype) !== 'alternative')) {
                 if (isset($this->plaintextMessage)) {


### PR DESCRIPTION
I was having trouble with fetching messages due to an illegal character when it was running the iconv() function.

```
[Symfony\Component\Debug\Exception\ContextErrorException]                                                                                  
  Notice: iconv(): Detected an illegal character in input string in /var/www/sites/cems2/vendor/tedivm/fetch/src/Fetch/Message.php line 430  
```

Since the purpose of using iconv() in this circumstance appears to be to convert it from its existing character set to utf-8, encoding the messageBody with utf8_encode() seemed appropriate. All tests and builds passed for me locally.
