### PR TITLE
html contains plaintext

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -448,7 +448,7 @@ class Message
                 }
 
                 $this->plaintextMessage .= trim($messageBody);
-            } elseif( strtolower($structure->subtype) ===  'html') {
+            } elseif (strtolower($structure->subtype) === 'html') {
                 if (isset($this->htmlMessage)) {
                     $this->htmlMessage .= '<br><br>';
                 } else {


### PR DESCRIPTION
"$message->getMessageBody(true)" contains plaintext and html content when the message is multipart/mixed and the message got the following content types:
"Content-Type: multipart/alternative;"
"Content-Type: text/plain;"
"Content-Type: text/html;"
