### PR TITLE
Added getMailboxes function

### DIFF
--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -182,7 +182,7 @@ class Server
 
         if (is_array($_boxes)) {
             foreach ($_boxes as $box) {
-                $boxes[] = str_replace($this->getServerString(), '', mb_convert_encoding($box, "UTF-8", "UTF7-IMAP"));
+                $boxes[] = str_replace($this->getServerString(), '', $box);
             }
         } else {
             throw new \RuntimeException(imap_last_error());

--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -174,6 +174,23 @@ class Server
         return $this->mailbox;
     }
 
+    public function getMailBoxes()
+    {
+        $_boxes = imap_list($this->getImapStream(), $this->getServerString(), "*");
+
+        $boxes = array();
+
+        if (is_array($_boxes)) {
+            foreach ($_boxes as $box) {
+                $boxes[] = str_replace($this->getServerString(), '', mb_convert_encoding($box, "UTF-8", "UTF7-IMAP"));
+            }
+        } else {
+            throw new \RuntimeException(imap_last_error());
+        }
+
+        return $boxes;
+    }
+
     /**
      * This function sets or removes flag specifying connection behavior. In many cases the flag is just a one word
      * deal, so the value attribute is not required. However, if the value parameter is passed false it will clear that

--- a/tests/Fetch/Test/ServerTest.php
+++ b/tests/Fetch/Test/ServerTest.php
@@ -139,12 +139,12 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Sent', $server->getMailBox());
     }
 
-	public function testGetMailboxes()
-	{
-		$box = ["INBOX","Sent","Flagged Email"];
-		$server = Static::getServer();
-		$this->assertEquals($box, $server->getMailBoxes());
-	}
+    public function testGetMailboxes()
+    {
+        $box = ["INBOX","Sent","Flagged Email"];
+        $server = Static::getServer();
+        $this->assertEquals($box, $server->getMailBoxes());
+    }
 
     public function testSetMailBox()
     {

--- a/tests/Fetch/Test/ServerTest.php
+++ b/tests/Fetch/Test/ServerTest.php
@@ -139,6 +139,13 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Sent', $server->getMailBox());
     }
 
+	public function testGetMailboxes()
+	{
+		$box = ["INBOX","Sent","Flagged Email"];
+		$server = Static::getServer();
+		$this->assertEquals($box, $server->getMailBoxes());
+	}
+
     public function testSetMailBox()
     {
         $server = Static::getServer();


### PR DESCRIPTION
Just want to see how this code would fail in travis. Possibly get this patch moved into core. Though there is an issue with the requirement of mb_convert_encoding not being a default enabled function. I'm inviting discussion on how to fix this. This is essentially a cleaned up version of #42.