### PR TITLE
Fix attachment encoding bug introduced in 6f09bdc2 

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -206,13 +206,11 @@ class Attachment
         }
 
         switch ($this->encoding) {
-            case 3:
-            case 'base64':
+            case 3: //base64
                 $streamFilter = stream_filter_append($filePointer, 'convert.base64-decode', STREAM_FILTER_WRITE);
                 break;
 
-            case 4:
-            case 'quoted-printable':
+            case 4: //quoted-printable
                 $streamFilter = stream_filter_append($filePointer, 'convert.quoted-printable-decode', STREAM_FILTER_WRITE);
                 break;
 


### PR DESCRIPTION
The case statement returned true for 0 == 'quoted-printable',
and base64 decoded all 7bit encoded attachments.
I have removed the string representations as an int is always
returned by PHP's imap functions for encoding type.
