### PR TITLE
Catch mb convert encoding exceptions

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -473,7 +473,7 @@ class Message
                         // @TODO Handle exception
                     }
                 }
-                if ( ! $mb_converted) {
+                if (!$mb_converted) {
                     try {
                         $messageBody = iconv($parameters['charset'], self::$charset . self::$charsetFlag, $messageBody);
                     } catch (Exception $e) {


### PR DESCRIPTION
Catch mb_convert_encoding exceptions, and default to iconv instead.

TODO: Handle the exceptions somehow. Not sure what would be the best way... Especially if both fail...
