### PR TITLE
UTF-8 Translation

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -93,9 +93,9 @@ class Attachment
         $parameters = Message::getParametersFromStructure($structure);
 
         if (isset($parameters['filename'])) {
-            $this->filename = $parameters['filename'];
+            $this->filename = imap_utf8($parameters['filename']);
         } elseif (isset($parameters['name'])) {
-            $this->filename = $parameters['name'];
+            $this->filename = imap_utf8($parameters['name']);
         }
 
         $this->size = $structure->bytes;

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -220,7 +220,7 @@ class Message
 
             return false;
 
-        $this->subject = isset($messageOverview->subject) ? $messageOverview->subject : null;
+        $this->subject = isset($messageOverview->subject) ? imap_utf8($messageOverview->subject) : null;
         $this->date    = strtotime($messageOverview->date);
         $this->size    = $messageOverview->size;
 


### PR DESCRIPTION
When a user tries to get the attachments name or the subject message can come across this type of writing: 
=?UTF-8?Q?Probl=C3=A8me_de_connexion?=
Instead of: 
Problème de connexion
The imap_utf8() function is precisely to solve this problem.