### PR TITLE
Added check on Message::processAddressObject()

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -611,10 +611,13 @@ class Message
         $outputAddresses = array();
         if (is_array($addresses))
             foreach ($addresses as $address) {
-                $currentAddress            = array();
-                $currentAddress['address'] = $address->mailbox . '@' . $address->host;
-                if (isset($address->personal))
-                    $currentAddress['name'] = $address->personal;
+                if (property_exists($address, 'mailbox') && $address->mailbox != 'undisclosed-recipients') {
+                    $currentAddress = array();
+                    $currentAddress['address'] = $address->mailbox . '@' . $address->host;
+                    if (isset($address->personal)) {
+                        $currentAddress['name'] = $address->personal;
+                    }
+                }
                 $outputAddresses[] = $currentAddress;
             }
 


### PR DESCRIPTION
Added check if the mail addresses are really a email address on  Message::processAddressObject()

The error is when the address is for example: undisclosed-recipients

Fixes issue #95 