### PR TITLE
Allow setFlags() to set multiple flags as an array + minor code reviews

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -77,7 +77,7 @@ class Message
      *
      * @var string
      */
-    protected static $flagTypes = array('recent', 'flagged', 'answered', 'deleted', 'seen', 'draft');
+    protected static $flagTypes = array(self::FLAG_RECENT, self::FLAG_FLAGGED, self::FLAG_ANSWERED, self::FLAG_DELETED, self::FLAG_SEEN, self::FLAG_DRAFT);
 
     /**
      * This holds the plantext email message.
@@ -671,7 +671,7 @@ class Message
      * @param  string $flag Recent, Flagged, Answered, Deleted, Seen, Draft
      * @return bool
      */
-    public function checkFlag($flag = 'flagged')
+    public function checkFlag($flag = self::FLAG_FLAGGED)
     {
         return (isset($this->status[$flag]) && $this->status[$flag] === true);
     }
@@ -686,7 +686,7 @@ class Message
      */
     public function setFlag($flag, $enable = true)
     {
-        if (!in_array($flag, self::$flagTypes) || $flag == 'recent')
+        if (!in_array($flag, self::$flagTypes) || $flag == self::FLAG_RECENT)
             throw new \InvalidArgumentException('Unable to set invalid flag "' . $flag . '"');
 
         $imapifiedFlag = '\\' . ucfirst($flag);

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -351,7 +351,7 @@ class Message
             }
         } else {
             if (!isset($this->plaintextMessage) && isset($this->htmlMessage)) {
-                $output = preg_replace('/\<br(\s*)?\/?\>/i', PHP_EOL, trim($this->htmlMessage) );
+                $output = preg_replace('/\s*\<br\s*\/?\>/i', PHP_EOL, trim($this->htmlMessage) );
                 $output = strip_tags($output);
 
                 return $output;


### PR DESCRIPTION
Added the possibility the set multiple message flags at one time by passing an array of flags. It is still possible to pass a single flag as a string.

Also replaced raw string flag values by class constants

And a minor regex optimization to convert <br /> to EOL, that also strip useless trailing spaces