### PR TITLE
Decode multiple lines UTF-8 subject

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -220,7 +220,16 @@ class Message
 
             return false;
 
-        $this->subject = isset($messageOverview->subject) ? $messageOverview->subject : null;
+        $this->subject = null;
+        if(isset($messageOverview->subject)){
+            $temp_subject = "";
+            $temp_decoded_subject = imap_mime_header_decode($messageOverview->subject);
+            foreach ($temp_decoded_subject as $value) {
+                $temp_subject .= $value->text;
+            }
+            $this->subject = $temp_subject;
+        }
+        
         $this->date    = strtotime($messageOverview->date);
         $this->size    = $messageOverview->size;
 


### PR DESCRIPTION
### Problem

UTF-8 Translation #90 by guiguidu31300 method using `imap_utf8()` to decode utf-8 subject. However, this approach can only solve single lines subject and unable to decode following "multiple lines subject".

````
Subject: =?UTF-8?B?UmU6IOOBiuWVj+OBhOWQiOOCj+OBm++8muODquOCr+ODq+ODvOODiOOBq+OBpOOBhOOBpg==?=
	=?UTF-8?B?44Gr44Gk44GE44Gm?=
````

### Solution

Decode utf-8 subject by `imap_mime_header_decode()` instead of `imap_utf8()`