### PR TITLE
Fix message decoding

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -541,17 +541,14 @@ class Message
             $encoding = strtolower($encoding);
         }
 
-        switch ($encoding) {
-            case 'base64':
-            case 3:
-            case 5:
-            case 6:
-            case 7:
-                return base64_decode($data);
-
-            case 'quoted-printable':
-            case 4:
+        switch (true) {
+            case $encoding === 'quoted-printable':
+            case $encoding === 4:
                 return quoted_printable_decode($data);
+
+            case $encoding === 'base64':
+            case $encoding === 3:
+                return base64_decode($data);
 
             default:
                 return $data;


### PR DESCRIPTION
Only append to `$this->htmlMessage` when the `subtype` is `HTML`.
