### PR TITLE
Fix for unsupported encodings

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -480,18 +480,22 @@ class Message
             if (!empty($parameters['charset']) && $parameters['charset'] !== self::$charset) {
                 $mb_converted = false;
                 if (function_exists('mb_convert_encoding')) {
-                    try {
-                        $messageBody = mb_convert_encoding($messageBody, self::$charset, $parameters['charset']);
-                        $mb_converted = true;
-                    } catch (Exception $e) {
-                        // @TODO Handle exception
+                    if (!in_array($parameters['charset'], mb_list_encodings())) {
+                        if ($structure->encoding === 0) {
+                            $parameters['charset'] = 'US-ASCII';
+                        } else {
+                            $parameters['charset'] = 'UTF-8';
+                        }
                     }
+
+                    $messageBody = @mb_convert_encoding($messageBody, self::$charset, $parameters['charset']);
+                    $mb_converted = true;
                 }
                 if (!$mb_converted) {
-                    try {
-                        $messageBody = iconv($parameters['charset'], self::$charset . self::$charsetFlag, $messageBody);
-                    } catch (Exception $e) {
-                        // @TODO Handle exception
+                    $messageBodyConv = @iconv($parameters['charset'], self::$charset . self::$charsetFlag, $messageBody);
+
+                    if ($messageBodyConv !== false) {
+                        $messageBody = $messageBodyConv;
                     }
                 }
             }


### PR DESCRIPTION
When using mb_convert_encoding, check identified charset against list of available encodings (as mentioned in #107). If none match use US-ASCII if encoding is 7-bit; UTF-8 otherwise.

When using iconv, suppress errors and check if the function returns false.

NOTE: removed the try/catch blocks, since neither mb_convert_encoding nor iconv throw exceptions, in it's place, any (undesired?) error output is being suppressed with @