### PR TITLE
Fix for Undefined Variable: $currentAddress

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -629,8 +629,8 @@ class Message
                     if (isset($address->personal)) {
                         $currentAddress['name'] = $address->personal;
                     }
+                    $outputAddresses[] = $currentAddress;
                 }
-                $outputAddresses[] = $currentAddress;
             }
 
         return $outputAddresses;


### PR DESCRIPTION
Here is a better fix for the undefined variable: $currentAddress warning. Only assign it if it is existing. Avoids the empty array issue mentioned with #118 