### PR TITLE
Added method to access mailbox properties - including IMAP separator character

### DIFF
--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -443,12 +443,24 @@ class Server
      */
     public function hasMailBox($mailbox)
     {
-        return (boolean) imap_getmailboxes(
-            $this->getImapStream(),
-            $this->getServerString(),
-            $this->getServerSpecification() . $mailbox
-        );
+        return (boolean) $this->getMailBoxDetails($mailbox);
     }
+
+	/**
+	 * Return information about the mailbox or mailboxes
+	 *
+	 * @param $mailbox
+	 *
+	 * @return bool
+	 */
+	public function getMailBoxDetails($mailbox)
+	{
+		return imap_getmailboxes(
+			$this->getImapStream(),
+			$this->getServerString(),
+			$this->getServerSpecification() . $mailbox
+		);
+	}
 
     /**
      * Creates the given mailbox.

--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -446,21 +446,21 @@ class Server
         return (boolean) $this->getMailBoxDetails($mailbox);
     }
 
-     /**
-      * Return information about the mailbox or mailboxes
-      *
-      * @param $mailbox
-      *
-      * @return bool
-      */
-     public function getMailBoxDetails($mailbox)
-     {
+    /**
+    * Return information about the mailbox or mailboxes
+    *
+    * @param $mailbox
+    *
+    * @return bool
+    */
+    public function getMailBoxDetails($mailbox)
+    {
         return imap_getmailboxes(
             $this->getImapStream(),
             $this->getServerString(),
             $this->getServerSpecification() . $mailbox
         );
-     }
+    }
 
     /**
      * Creates the given mailbox.

--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -446,21 +446,21 @@ class Server
         return (boolean) $this->getMailBoxDetails($mailbox);
     }
 
-	/**
-	 * Return information about the mailbox or mailboxes
-	 *
-	 * @param $mailbox
-	 *
-	 * @return bool
-	 */
-	public function getMailBoxDetails($mailbox)
-	{
-		return imap_getmailboxes(
-			$this->getImapStream(),
-			$this->getServerString(),
-			$this->getServerSpecification() . $mailbox
-		);
-	}
+     /**
+      * Return information about the mailbox or mailboxes
+      *
+      * @param $mailbox
+      *
+      * @return bool
+      */
+     public function getMailBoxDetails($mailbox)
+     {
+        return imap_getmailboxes(
+            $this->getImapStream(),
+            $this->getServerString(),
+            $this->getServerSpecification() . $mailbox
+        );
+     }
 
     /**
      * Creates the given mailbox.


### PR DESCRIPTION
To access mailbox properties, you needed to call imap_getmailboxes(). However, the hasMailbox() function was calling this function but simply returning the result as a boolean, ignoring the useful data that the function returns - which crucially includes the IMAP separator character.

This PR simply adds another method - getMailboxDetails() - which can return the data from the imap_getmailboxes() function.

We then modify the hasMailbox() method to call getMailboxDetails() and return the result as a boolean. Fully backwards compatible.

Fixes issue #101 