### PR TITLE
Fix an issue where the IMAP stream isn't reloaded after it's lost.

### DIFF
--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -250,7 +250,7 @@ class Server
      */
     public function getImapStream()
     {
-        if (!isset($this->imapStream))
+        if (empty($this->imapStream))
             $this->setImapStream();
 
         return $this->imapStream;
@@ -302,7 +302,7 @@ class Server
      */
     protected function setImapStream()
     {
-        if (isset($this->imapStream)) {
+        if (!empty($this->imapStream)) {
             if (!imap_reopen($this->imapStream, $this->getServerString(), $this->options, 1))
                 throw new \RuntimeException(imap_last_error());
         } else {


### PR DESCRIPTION
If `$this->imapStream` is lost, it will return `0`. These conditionals evaluated `0` as a set variable, therefore they didn't reload the stream even though they should have. Using empty() instead ensures that `$this->imapStream` is set *and* not `0`.