### PR TITLE
getRawHeaders

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -43,12 +43,12 @@ class Message
      */
     protected $imapStream;
 
-	/**
-	 * This as an string which contains raw header information for the message.
-	 *
-	 * @var string
-	 */
-	protected $rawHeaders;
+    /**
+     * This as an string which contains raw header information for the message.
+     *
+     * @var string
+     */
+    protected $rawHeaders;
 
     /**
      * This as an object which contains header information for the message.
@@ -298,23 +298,23 @@ class Message
         return $this->messageOverview;
     }
 
-	/**
-	 * This function returns an object containing the raw headers of the message.
-	 *
-	 * @param  bool      $forceReload
-	 * @return string
-	 */
-	public function getRawHeaders($forceReload = false)
-	{
-		if ($forceReload || !isset($this->rawHeaders)) {
-			// raw headers (since imap_headerinfo doesn't use the unique id)
-			$this->rawHeaders = imap_fetchheader($this->imapStream, $this->uid, FT_UID);
-		}
+    /**
+     * This function returns an object containing the raw headers of the message.
+     *
+     * @param  bool      $forceReload
+     * @return string
+     */
+    public function getRawHeaders($forceReload = false)
+    {
+        if ($forceReload || !isset($this->rawHeaders)) {
+            // raw headers (since imap_headerinfo doesn't use the unique id)
+            $this->rawHeaders = imap_fetchheader($this->imapStream, $this->uid, FT_UID);
+        }
 
-		return $this->rawHeaders;
-	}
+        return $this->rawHeaders;
+    }
 
-	/**
+    /**
      * This function returns an object containing the headers of the message. This is done by taking the raw headers
      * and running them through the imap_rfc822_parse_headers function. The results are only retrieved from the server
      * once unless passed true as a parameter.

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -44,7 +44,7 @@ class Message
     protected $imapStream;
 
 	/**
-	 * This as an object which contains raw header information for the message.
+	 * This as an string which contains raw header information for the message.
 	 *
 	 * @var string
 	 */

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -301,7 +301,7 @@ class Message
     /**
      * This function returns an object containing the raw headers of the message.
      *
-     * @param  bool      $forceReload
+     * @param  bool   $forceReload
      * @return string
      */
     public function getRawHeaders($forceReload = false)

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -43,6 +43,13 @@ class Message
      */
     protected $imapStream;
 
+	/**
+	 * This as an object which contains raw header information for the message.
+	 *
+	 * @var string
+	 */
+	protected $rawHeaders;
+
     /**
      * This as an object which contains header information for the message.
      *
@@ -291,7 +298,23 @@ class Message
         return $this->messageOverview;
     }
 
-    /**
+	/**
+	 * This function returns an object containing the raw headers of the message.
+	 *
+	 * @param  bool      $forceReload
+	 * @return string
+	 */
+	public function getRawHeaders($forceReload = false)
+	{
+		if ($forceReload || !isset($this->rawHeaders)) {
+			// raw headers (since imap_headerinfo doesn't use the unique id)
+			$this->rawHeaders = imap_fetchheader($this->imapStream, $this->uid, FT_UID);
+		}
+
+		return $this->rawHeaders;
+	}
+
+	/**
      * This function returns an object containing the headers of the message. This is done by taking the raw headers
      * and running them through the imap_rfc822_parse_headers function. The results are only retrieved from the server
      * once unless passed true as a parameter.
@@ -303,7 +326,7 @@ class Message
     {
         if ($forceReload || !isset($this->headers)) {
             // raw headers (since imap_headerinfo doesn't use the unique id)
-            $rawHeaders = imap_fetchheader($this->imapStream, $this->uid, FT_UID);
+            $rawHeaders = $this->getRawHeaders();
 
             // convert raw header string into a usable object
             $headerObject = imap_rfc822_parse_headers($rawHeaders);


### PR DESCRIPTION
Added a function which returns raw headers. Useful when you need stuff that imap_rfc822_parse_headers() doesn't recognize. 