### PR TITLE
Add decodeHeader function

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -475,6 +475,22 @@ class Message
     {
         return isset($this->subject) ? $this->subject : null;
     }
+    
+    /**
+     * Decode a header to a flat string
+     *
+     * @return string
+     */
+    public function flatDecodeHeader($header)
+    {
+        $array = imap_mime_header_decode($header);
+        $str = '';
+        foreach ( $array as $part ) {
+            $str .= $part->text;
+        }
+
+        return $str;
+    }
 
     /**
      * This function marks a message for deletion. It is important to note that the message will not be deleted form the

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -477,11 +477,11 @@ class Message
     }
     
     /**
-     * Decode a header to a flat string
+     * Decode a header
      *
      * @return string
      */
-    public function flatDecodeHeader($header)
+    public function decodeHeader($header)
     {
         $array = imap_mime_header_decode($header);
         $str = '';


### PR DESCRIPTION
Decodes a header to a flat string.
Decodes "=?UTF-8?Q?" headers (such a subject) to a string

Example:
$message->decodeHeader($message->getSubject());

Should potentially be run on all data returned by $message->getSubject() etc.