### PR TITLE
Provide mime text decoder by RFC2047

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -93,9 +93,9 @@ class Attachment
         $parameters = Message::getParametersFromStructure($structure);
 
         if (isset($parameters['filename'])) {
-            $this->filename = imap_utf8($parameters['filename']);
+            $this->setFileName($parameters['filename']);
         } elseif (isset($parameters['name'])) {
-            $this->filename = imap_utf8($parameters['name']);
+            $this->setFileName($parameters['name']);
         }
 
         $this->size = $structure->bytes;
@@ -230,5 +230,10 @@ class Attachment
         fclose($filePointer);
 
         return $result;
+    }
+
+    protected function setFileName($text)
+    {
+        $this->filename = MIME::decode($text, Message::$charset);
     }
 }

--- a/src/Fetch/MIME.php
+++ b/src/Fetch/MIME.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Fetch package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fetch;
+
+/**
+ * This library is a wrapper around the Imap library functions included in php.
+ *
+ * @package Fetch
+ * @author  Robert Hafner <tedivm@tedivm.com>
+ * @author  Sergey Linnik <linniksa@gmail.com>
+ */
+final class MIME
+{
+    /**
+     * @param string $text
+     * @param string $targetCharset
+     *
+     * @return string
+     */
+    public static function decode($text, $targetCharset = 'utf-8')
+    {
+        if (null === $text) {
+            return null;
+        }
+
+        $result = '';
+
+        foreach (imap_mime_header_decode($text) as $word) {
+            $ch = 'default' === $word->charset ? 'ascii' : $word->charset;
+
+            $result .= iconv($ch, $targetCharset, $word->text);
+        }
+
+        return $result;
+    }
+}

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -233,7 +233,7 @@ class Message
 
             return false;
 
-        $this->subject = isset($messageOverview->subject) ? imap_utf8($messageOverview->subject) : null;
+        $this->subject = MIME::decode($messageOverview->subject, self::$charset);
         $this->date    = strtotime($messageOverview->date);
         $this->size    = $messageOverview->size;
 
@@ -674,7 +674,7 @@ class Message
                     $currentAddress = array();
                     $currentAddress['address'] = $address->mailbox . '@' . $address->host;
                     if (isset($address->personal)) {
-                        $currentAddress['name'] = $address->personal;
+                        $currentAddress['name'] = MIME::decode($address->personal, self::$charset);
                     }
                     $outputAddresses[] = $currentAddress;
                 }

--- a/tests/Fetch/Test/MIMETest.php
+++ b/tests/Fetch/Test/MIMETest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Fetch library.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fetch\Test;
+
+use Fetch\MIME;
+
+/**
+ * @package Fetch
+ * @author  Robert Hafner <tedivm@tedivm.com>
+ * @author  Sergey Linnik <linniksa@gmail.com>
+ */
+class MIMETest extends \PHPUnit_Framework_TestCase
+{
+    public function decodeData()
+    {
+        return array(
+            array(null, null),
+            array('Just text', 'Just text'),
+            array('Keith Moore <moore@cs.utk.edu>', '=?US-ASCII?Q?Keith_Moore?= <moore@cs.utk.edu>'),
+            array('Keld Jørn Simonsen <keld@dkuug.dk>', '=?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <keld@dkuug.dk>'),
+            array('André Pirard <PIRARD@vm1.ulg.ac.be>', '=?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>'),
+            array(
+                'If you can read this you understand the example.',
+                '=?ISO-8859-1?B?SWYgeW91IGNhbiByZWFkIHRoaXMgeW8=?='
+                . PHP_EOL .
+                '=?ISO-8859-2?B?dSB1bmRlcnN0YW5kIHRoZSBleGFtcGxlLg==?='
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider decodeData
+     *
+     * @param string $expected
+     * @param string $text
+     * @param string $charset
+     */
+    public function testDecode($expected, $text, $charset = 'UTF-8')
+    {
+        self::assertSame($expected, MIME::decode($text, $charset));
+    }
+}


### PR DESCRIPTION
Replace usage of imap_utf8, and add decode address name.

this replace #83, #100, #146 pull requests