### PR TITLE
Fix outlook charset problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.3.0"
+  },
+  "suggest": {
     "ext-imap": "*"
   },
   "require-dev": {

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -524,10 +524,8 @@ class Message
                 $mb_converted = false;
                 if (function_exists('mb_convert_encoding')) {
                     if (!in_array($parameters['charset'], mb_list_encodings())) {
-                        if ($structure->encoding === 0) {
+                        if (empty($structure->encoding)) {
                             $parameters['charset'] = 'US-ASCII';
-                        } else {
-                            $parameters['charset'] = 'UTF-8';
                         }
                     }
 


### PR DESCRIPTION
When I send email from outlook desktop client v10, with utf8 chars (šđčćž), the library converts them to question marks. This is because outlook sends message in iso-8859-2 charset, and mb_convert_encoding expect from charset to be the real one, but this if block converts original charset to utf-8. This is how I fix it.
