### PR TITLE
Added switch to avoid 'incomplete multibyte character' when converting utf-8 to utf-8

### DIFF
--- a/src/Fetch/MIME.php
+++ b/src/Fetch/MIME.php
@@ -37,7 +37,9 @@ final class MIME
         foreach (imap_mime_header_decode($text) as $word) {
             $ch = 'default' === $word->charset ? 'ascii' : $word->charset;
 
-            $result .= iconv($ch, $targetCharset, $word->text);
+            if (strtoupper($ch) != strtoupper($targetCharset)) {
+                $result .= iconv($ch, $targetCharset, $word->text);
+            }
         }
 
         return $result;


### PR DESCRIPTION
We had an issue with german characters like "ü".
Error message was 
```
iconv(): Detected an incomplete multibyte character in input string
in /var/www/api/vendor/tedivm/fetch/src/Fetch/MIME.php:39
```
This only happened when both charactersets were utf-8, so conversion weren't neccessary anyway.