### PR TITLE
Check for host property on address object

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -98,7 +98,9 @@ class Attachment
             $this->setFileName($parameters['name']);
         }
 
-        $this->size = $structure->bytes;
+        if (isset($structure->bytes)) {
+            $this->size = $structure->bytes;
+        }
 
         $this->mimeType = Message::typeIdToString($structure->type);
 

--- a/src/Fetch/MIME.php
+++ b/src/Fetch/MIME.php
@@ -37,7 +37,7 @@ final class MIME
         foreach (imap_mime_header_decode($text) as $word) {
             $ch = 'default' === $word->charset ? 'ascii' : $word->charset;
 
-            $result .= iconv($ch, $targetCharset, $word->text);
+            $result .= iconv($ch, $targetCharset.'//TRANSLIT', $word->text);
         }
 
         return $result;

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -111,7 +111,7 @@ class Message
      *
      * @var string
      */
-    protected $subject;
+    protected $subject = '';
 
     /**
      * This is the size of the email.
@@ -229,11 +229,12 @@ class Message
 
         /* First load the message overview information */
 
-        if(!is_object($messageOverview = $this->getOverview()))
+        if(!is_object($messageOverview = $this->getOverview())) return false;
+        
+        if( isset($messageOverview->subject)) {
+            $this->subject = MIME::decode($messageOverview->subject, self::$charset);
+        }
 
-            return false;
-
-        $this->subject = MIME::decode($messageOverview->subject, self::$charset);
         $this->date    = strtotime($messageOverview->date);
         $this->size    = $messageOverview->size;
 

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -670,7 +670,7 @@ class Message
         $outputAddresses = array();
         if (is_array($addresses))
             foreach ($addresses as $address) {
-                if (property_exists($address, 'mailbox') && $address->mailbox != 'undisclosed-recipients') {
+                if (property_exists($address, 'mailbox') && property_exists($address, 'host')) {
                     $currentAddress = array();
                     $currentAddress['address'] = $address->mailbox . '@' . $address->host;
                     if (isset($address->personal)) {


### PR DESCRIPTION
Issue #165 . Check for host property on address object to account for different versions of "undisclosed recipients".  "undisclosed recipients" could have several different variations, it won't always be "undisclosed-recipients".  Checking for the existence of the host property handles this issue.