### PR TITLE
Fix encoding bug

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -523,7 +523,7 @@ class Message
             if (!empty($parameters['charset']) && $parameters['charset'] !== self::$charset) {
                 $mb_converted = false;
                 if (function_exists('mb_convert_encoding')) {
-                    if (!in_array(strtoupper($parameters['charset']), mb_list_encodings())) {
+                    if (!in_array(strtoupper($parameters['charset']), array_map('strtoupper', mb_list_encodings()))) {
                         if ($structure->encoding === 0) {
                             $parameters['charset'] = 'US-ASCII';
                         } else {

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -523,7 +523,7 @@ class Message
             if (!empty($parameters['charset']) && $parameters['charset'] !== self::$charset) {
                 $mb_converted = false;
                 if (function_exists('mb_convert_encoding')) {
-                    if (!in_array($parameters['charset'], mb_list_encodings())) {
+                    if (!in_array(strtoupper($parameters['charset']), mb_list_encodings())) {
                         if ($structure->encoding === 0) {
                             $parameters['charset'] = 'US-ASCII';
                         } else {


### PR DESCRIPTION
in_array() is case-sensitive and $parameters['charset'] is lower-case while mb_list_encodings() is upper-case
