### PR TITLE
Add function to fetch and clear imap errors

### DIFF
--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -440,6 +440,16 @@ class Server
     }
 
     /**
+     * This function returns all the imap errors to prevent the following
+     * warning from imap_close and imap_expunge
+     * 'Unknown: Warning: MIME header encountered in non-MIME message (errflg=3)'
+     */
+    public function getImapErrors()
+    {
+        return imap_errors();
+    }
+
+    /**
      * This function removes all of the messages flagged for deletion from the mailbox.
      *
      * @return bool


### PR DESCRIPTION
I was getting a lot of errors when fetching emails : Notice: Unknown: Warning: MIME header encountered in non-MIME message (errflg=3) in Unknown on line 0
The error message is emitted when you call imap_close(), or, in that function's absence, when the script ends. Call imap_errors() before that (to clear the error stack).

http://stackoverflow.com/questions/3378469/how-to-get-rid-of-error-messages-with-phps-imap-fetchstructure

call popServer->getImapErrors() to clear the error list