### PR TITLE
Only replace a flag when everything before the "=" match.

### DIFF
--- a/src/Fetch/Server.php
+++ b/src/Fetch/Server.php
@@ -210,7 +210,7 @@ class Server
             if ($value == false && $index !== false) {
                 unset($this->flags[$index]);
             } elseif ($value != false) {
-                $match = preg_grep('/' . $flag . '/', $this->flags);
+                $match = preg_grep('/\A' . $flag . '(?==)/', $this->flags);
                 if (reset($match)) {
                     $this->flags[key($match)] = $flag . '=' . $value;
                 } else {


### PR DESCRIPTION
Currently the flag "user" will replace the flag "authuser". This diff makes sure everything before the "=" is matched before replacing the flag.