### PR TITLE
Process root element of embedded emails

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -562,15 +562,21 @@ class Message
             }
         }
 
-        if (isset($structure->parts)) { // multipart: iterate through each part
+        if (! empty($structure->parts)) {
 
-            foreach ($structure->parts as $partIndex => $part) {
-                $partId = $partIndex + 1;
+            if (isset($structure->subtype) && strtolower($structure->subtype) === 'rfc822') {
+                // rfc822: The root part is processed with the current part identifier
+                $this->processStructure($structure->parts[0], $partIdentifier);
+            } else {
+                // multipart: iterate through each part
+                foreach ($structure->parts as $partIndex => $part) {
+                    $partId = $partIndex + 1;
 
-                if (isset($partIdentifier))
-                    $partId = $partIdentifier . '.' . $partId;
+                    if (isset($partIdentifier))
+                        $partId = $partIdentifier . '.' . $partId;
 
-                $this->processStructure($part, $partId);
+                    $this->processStructure($part, $partId);
+                }
             }
         }
     }


### PR DESCRIPTION
An email with an embedded email can have the following structure:

1: "text/plain"
2: "message/rfc822"
2: "multipart/mixed"
2.1: "text/plain"
2.2: "application/octet-stream"
2.3, "application/octet-stream"

Before this fix this structure was parsed as

1: "text/plain"
2: "message/rfc822"
2.1: "multipart/mixed"
2.1.1: "text/plain"
2.1.2: "application/octet-stream"
2.1.3, "application/octet-stream"

Hence, downloading attachments was not possible due to wrong part
identifiers

resolves #188, #43