### PR TITLE
Fix to handle legacy uuencoded attachments.

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -98,6 +98,10 @@ class Attachment
             $this->setFileName($parameters['name']);
         }
 
+        if (isset($structure->data)) {
+            $this->data = $structure->data;
+        }
+
         $this->size = $structure->bytes;
 
         $this->mimeType = Message::typeIdToString($structure->type);
@@ -218,10 +222,14 @@ class Attachment
                 $streamFilter = null;
         }
 
-        // Fix an issue causing server to throw an error
-        // See: https://github.com/tedious/Fetch/issues/74 for more details
-        $fetch  = imap_fetchbody($this->imapStream, $this->messageId, $this->partId ?: 1, FT_UID);
-        $result = imap_savebody($this->imapStream, $filePointer, $this->messageId, $this->partId ?: 1, FT_UID);
+        if (isset($this->data)) {
+            $result = fwrite($filePointer, $this->data);
+        } else {
+            // Fix an issue causing server to throw an error
+            // See: https://github.com/tedious/Fetch/issues/74 for more details
+            $fetch  = imap_fetchbody($this->imapStream, $this->messageId, $this->partId ?: 1, FT_UID);
+            $result = imap_savebody($this->imapStream, $filePointer, $this->messageId, $this->partId ?: 1, FT_UID);
+        }
 
         if ($streamFilter) {
             stream_filter_remove($streamFilter);


### PR DESCRIPTION
Needs PECL mailparse >= 0.9.0 (tested with mailparse 2.1.6 on PHP 5.3)

What's uuencoded attachments: https://msdn.microsoft.com/en-us/library/office/aa579638(v=exchg.140).aspx