### PR TITLE
Switch to !empty instead of isset

### DIFF
--- a/src/Fetch/Attachment.php
+++ b/src/Fetch/Attachment.php
@@ -92,9 +92,9 @@ class Attachment
 
         $parameters = Message::getParametersFromStructure($structure);
 
-        if (isset($parameters['filename'])) {
+        if (!empty($parameters['filename'])) {
             $this->setFileName($parameters['filename']);
-        } elseif (isset($parameters['name'])) {
+        } elseif (!empty($parameters['name'])) {
             $this->setFileName($parameters['name']);
         }
 


### PR DESCRIPTION
Helpful in case of corrupted attachment properties.

Minor hotfix.

What we recently found is that when autoresend from gmail to yandex -- someone "kills" filename property of attachments. It becomes just empty. So instead of isset it's better use !empty.

Code coverage not changed. Tests was run locally.

ps: Btw, it's better to switch to docker already ))