### PR TITLE
More preciese mbstring encoding support check

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -576,6 +576,8 @@ class Message
     }
 
     /**
+     * Checks if $encoding is supported by mbstring extension
+     *
      * @param string $encoding
      *
      * @return bool

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -11,8 +11,6 @@
 
 namespace Fetch;
 
-use function strtolower;
-
 /**
  * This library is a wrapper around the Imap library functions included in php. This class represents a single email
  * message as retrieved from the Imap.
@@ -235,7 +233,7 @@ class Message
 
             return false;
 
-        $this->subject = isset($messageOverview->subject) ? imap_utf8($messageOverview->subject) : null;
+        $this->subject = MIME::decode($messageOverview->subject, self::$charset);
         $this->date    = strtotime($messageOverview->date);
         $this->size    = $messageOverview->size;
 
@@ -587,12 +585,12 @@ class Message
         static $list = null;
 
         if ($list === null) {
-            $list = array_map(function ($encoding) {
-                return strtolower($encoding);
-            }, mb_list_encodings());
+            $list = \array_map(function ($encoding) {
+                return \strtolower($encoding);
+            }, \mb_list_encodings());
         }
 
-        return in_array($encoding, $list, true);
+        return \in_array($encoding, $list, true);
     }
 
     /**
@@ -694,7 +692,7 @@ class Message
                     $currentAddress = array();
                     $currentAddress['address'] = $address->mailbox . '@' . $address->host;
                     if (isset($address->personal)) {
-                        $currentAddress['name'] = $address->personal;
+                        $currentAddress['name'] = MIME::decode($address->personal, self::$charset);
                     }
                     $outputAddresses[] = $currentAddress;
                 }

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -592,7 +592,7 @@ class Message
             }, \mb_list_encodings());
         }
 
-        return \in_array($encoding, $list, true);
+        return \in_array(\strtolower($encoding), $list, true);
     }
 
     /**


### PR DESCRIPTION
Full description is in #206.
TL;DR: encoding from boundary can be in different case than `mb_list_encodings()` output.